### PR TITLE
Renamed class/protocol, added support for multiple passcodes and delegates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ Things that are working:
   - Lock with/without the code
   - Toggle the code On/Off
 
+Things that need tested:
+
+  - Detect when a certain password is entered (using the LibPassDelegate)
+  - Accepting multiple passcodes (also using the LibPassDelegate)
+
 To-do list:
 
   - Clean up code (a lot)
-  - Detect when a certain password is entered
-  - Accept multiple passcodes
   - etc.
 
   

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -16,6 +16,35 @@
     return instance;
 }
 
+- (id) init
+{
+    delegates = [[NSMutableArray alloc] init];
+    return [super init];
+}
+
+-(BOOL) isDelegateRegistered:(id)delegate
+{
+    return [delegates indexOfObject:delegate] != NSNotFound;
+}
+
+-(void) registerDelegate:(id)delegate
+{
+    if ([self isDelegateRegistered:delegate] || delegate == nil)
+        return;
+    
+    [delegates addObject:delegate];
+}
+-(void) deregisterDelegate:(id)delegate
+{
+    if (![self isDelegateRegistered:delegate] || delegate == nil)
+        return;
+
+    NSUInteger num = [delegates indexOfObject:delegate];
+    if (NSNotFound == num)
+        return;
+    [delegates removeObjectAtIndex:num];
+}
+
 - (void)unlockWithCodeEnabled:(BOOL)enabled 
 {
     if (enabled) {
@@ -62,8 +91,13 @@
 }
 
 -(void)passwordWasEnteredHandler:(NSString *)password {
-    if (self.delegate)
-        [self.delegate passwordWasEntered:password];
+    for (id delegate in delegates)
+    {
+        if (delegate && [delegate conformsToProtocol:@protocol(LibPassDelegate)])
+        {
+            [delegate passwordWasEntered:password];
+        }
+    }
 }
 @end
 

--- a/libPass.h
+++ b/libPass.h
@@ -40,7 +40,8 @@ NSString* getUDID()
 
 @protocol LibPassDelegate <NSObject>
 @optional
--(void)passwordWasEntered:(NSString *)password;
+-(void)passwordWasEntered:(NSString*)password;
+-(BOOL)shouldAllowPasscode:(NSString*)password;
 @end
 
 @interface LibPass : NSObject
@@ -55,9 +56,10 @@ NSString* getUDID()
 
 + (instancetype) sharedInstance;
 
-- (void)passwordWasEnteredHandler:(NSString *)password;
-- (void)togglePasscode;
-- (void)setPasscodeToggle:(BOOL)enabled;
-- (void)unlockWithCodeEnabled:(BOOL)enabled;
-- (void)lockWithCodeEnabled:(BOOL)enabled;
+- (BOOL) shouldAllowPasscode:(NSString*)passcode;
+- (void) passwordWasEnteredHandler:(NSString *)password;
+- (void) togglePasscode;
+- (void) setPasscodeToggle:(BOOL)enabled;
+- (void) unlockWithCodeEnabled:(BOOL)enabled;
+- (void) lockWithCodeEnabled:(BOOL)enabled;
 @end

--- a/libPass.h
+++ b/libPass.h
@@ -40,7 +40,9 @@ NSString* getUDID()
 
 @protocol LibPassDelegate <NSObject>
 @optional
+// Used to allow basic detection of different passcodes
 -(void)passwordWasEntered:(NSString*)password;
+// Used during shouldAllowPasscode: to check if the passcode is "correct"
 -(BOOL)shouldAllowPasscode:(NSString*)password;
 @end
 
@@ -56,6 +58,8 @@ NSString* getUDID()
 
 + (instancetype) sharedInstance;
 
+- (void) registerDelegate:(id)delegate;
+- (void) deregisterDelegate:(id)delegate;
 - (BOOL) shouldAllowPasscode:(NSString*)passcode;
 - (void) passwordWasEnteredHandler:(NSString *)password;
 - (void) togglePasscode;

--- a/libPass.h
+++ b/libPass.h
@@ -38,12 +38,12 @@ NSString* getUDID()
 - (void)observer:(id)observer addBulletin:(BBBulletinRequest *)bulletin forFeed:(int)feed;
 @end
 
-@protocol libPassEvents <NSObject>
+@protocol LibPassDelegate <NSObject>
 @optional
 -(void)passwordWasEntered:(NSString *)password;
 @end
 
-@interface libPass : NSObject <libPassEvents> 
+@interface LibPass : NSObject
 @property (retain) id delegate;
 // This is probably a really bad idea...
 @property (nonatomic, retain) NSString* devicePasscode;

--- a/libPass.h
+++ b/libPass.h
@@ -44,8 +44,12 @@ NSString* getUDID()
 @end
 
 @interface LibPass : NSObject
+{
+    NSMutableArray *delegates;
+}
+
 @property (retain) id delegate;
-// This is probably a really bad idea...
+// This is probably a really, really bad idea...
 @property (nonatomic, retain) NSString* devicePasscode;
 @property (nonatomic) BOOL isPasscodeOn;
 


### PR DESCRIPTION
Changes:
- Renamed class and protocol
- Added support for multiple delegates
- Accepts multiple passcodes (using LibPassDelegate, so something like TimePasscode is theoretically possible to implement with LibPassword now)
